### PR TITLE
Simplified next.config.js as Next.js 8.1.1+ has built-in support for TypeScript

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,16 +1,8 @@
 // next.config.js
 const withCSS = require("@zeit/next-css");
-const withTypescript = require("@zeit/next-typescript");
-const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 
-module.exports = withTypescript(
-  withCSS({
-    webpack(config, options) {
-      // Do not run type checking twice:
-      if (options.isServer)
-        config.plugins.push(new ForkTsCheckerWebpackPlugin());
-
-      return config;
-    }
-  })
-);
+module.exports = withCSS({
+  webpack(config, options) {
+    return config;
+  }
+});


### PR DESCRIPTION
@robin-thomas As you have pointed out, there is no need in the TypeScript configuration in the `next.config.js` since Next.js 8.1.1 (we use a canary build) optionally configures it out of the box (we still need to explicitly list the typescript dependencies in `package.json`).