### PR TITLE
Migrated timestamps type into BIGINT (milliseconds) instead of strings

### DIFF
--- a/backend/migrations/20190725-01-migrate-timestamps-and-heights-to-bigint.js
+++ b/backend/migrations/20190725-01-migrate-timestamps-and-heights-to-bigint.js
@@ -1,0 +1,37 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async t => {
+      await queryInterface.changeColumn(
+        "nodes",
+        "last_height",
+        {
+          type: Sequelize.BIGINT,
+          allowNull: false
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.changeColumn(
+        "nodes",
+        "last_seen",
+        {
+          type: Sequelize.BIGINT,
+          allowNull: false
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.changeColumn(
+        "blocks",
+        "timestamp",
+        {
+          type: Sequelize.BIGINT,
+          allowNull: false
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {}
+};

--- a/backend/models/Block.js
+++ b/backend/models/Block.js
@@ -18,7 +18,7 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false
       },
       timestamp: {
-        type: DataTypes.STRING,
+        type: DataTypes.BIGINT,
         allowNull: false
       },
       weight: {

--- a/backend/models/Node.js
+++ b/backend/models/Node.js
@@ -25,12 +25,12 @@ module.exports = (sequelize, DataTypes) => {
       },
       lastSeen: {
         field: "last_seen",
-        type: DataTypes.STRING,
+        type: DataTypes.BIGINT,
         allowNull: false
       },
       lastHeight: {
         field: "last_height",
-        type: DataTypes.STRING,
+        type: DataTypes.BIGINT,
         allowNull: false
       }
     },

--- a/frontend/components/Block.js
+++ b/frontend/components/Block.js
@@ -104,7 +104,7 @@ const Block = ({ block }) => {
             <Col md="4">
               <BlockCard
                 title="Created"
-                text={moment(parseInt(block.timestamp.substring(0, 13))).format(
+                text={moment(block.timestamp).format(
                   "MMMM DD, YYYY [at] h:mm:ssa"
                 )}
                 textCls="block-card-created-text"

--- a/frontend/components/blocks/BlocksRow.js
+++ b/frontend/components/blocks/BlocksRow.js
@@ -61,7 +61,7 @@ const BlocksRow = props => (
             <Col className="transaction-row-timer">
               <span className="transaction-row-timer-status">Completed</span>
               &nbsp;&nbsp;
-              <Timer time={parseInt(props.block.timestamp.substring(0, 13))} />
+              <Timer time={props.block.timestamp} />
             </Col>
           </Row>
         </Col>

--- a/frontend/components/dashboard/DashboardBlocksBlock.js
+++ b/frontend/components/dashboard/DashboardBlocksBlock.js
@@ -43,9 +43,7 @@ const DashboardBlocksBlock = props => (
               </Col>
               <Col md="5" xs="5" className="align-self-center text-right">
                 <span className="dashboard-blocks-block-timer">
-                  <Timer
-                    time={parseInt(props.blockTimestamp.substring(0, 13))}
-                  />
+                  <Timer time={props.blockTimestamp} />
                 </span>
               </Col>
             </Row>

--- a/frontend/components/dashboard/transaction/transaction.js
+++ b/frontend/components/dashboard/transaction/transaction.js
@@ -28,7 +28,7 @@ const TransactionRow = props => (
           <Row>
             <Col className="dashboard-transaction-timer">
               {`${props.txStatus} `}
-              <Timer time={parseInt(props.blockTimestamp.substring(0, 13))} />
+              <Timer time={props.blockTimestamp} />
             </Col>
           </Row>
         </Col>

--- a/frontend/components/transactions/TransactionsRow.js
+++ b/frontend/components/transactions/TransactionsRow.js
@@ -43,7 +43,7 @@ const TransactionsRow = props => (
             {props.txn.status}
           </span>
           &nbsp;&nbsp;
-          <Timer time={parseInt(props.txn.blockTimestamp.substring(0, 13))} />
+          <Timer time={props.txn.blockTimestamp} />
         </Col>
       </Row>
     </Col>


### PR DESCRIPTION
@robin-thomas FYI, I have changed the internal storage for timestamps (`blocks.timestamp` and `nodes.last_seen`) to save data as [UNIX epoch] milliseconds, and it is now a number type instead of a string.