### PR TITLE
Exposed (proxy) Nearcore query API via backend (#53)

### DIFF
--- a/backend/src/near.js
+++ b/backend/src/near.js
@@ -1,0 +1,7 @@
+const nearlib = require("nearlib");
+
+const { nearRpcUrl } = require("./config");
+
+const nearRpc = new nearlib.providers.JsonRpcProvider(nearRpcUrl);
+
+exports.nearRpc = nearRpc;

--- a/backend/src/sync.js
+++ b/backend/src/sync.js
@@ -1,18 +1,14 @@
 const bs58 = require("bs58");
 
-const nearlib = require("nearlib");
-
 const models = require("../models");
 
 const {
-  nearRpcUrl,
   syncFetchQueueSize,
   syncSaveQueueSize,
   bulkDbUpdateSize
 } = require("./config");
+const { nearRpc } = require("./near");
 const { toBase58, Result } = require("./utils");
-
-const nearRpc = new nearlib.providers.JsonRpcProvider(nearRpcUrl);
 
 async function saveBlocks(blocksInfo) {
   try {

--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -6,6 +6,7 @@ const {
   wampNearExplorerUrl,
   wampNearExplorerBackendSecret
 } = require("./config");
+const { nearRpc } = require("./near");
 
 const wampHandlers = {};
 
@@ -26,6 +27,10 @@ wampHandlers["select"] = async ([query, replacements]) => {
     replacements,
     type: models.Sequelize.QueryTypes.SELECT
   });
+};
+
+wampHandlers["nearcore-query"] = async ([path, data]) => {
+  return await nearRpc.query(path, data);
 };
 
 function setupWamp() {


### PR DESCRIPTION
/cc @robin-thomas 

We can now query Nearcore from frontend via WAMP:

```js
await call(".nearcore-query", ["account/register.near", ""])
```