### PR TITLE
Use x-forwarded-for as a source of node IP address

### DIFF
--- a/frontend/pages/api/nodes.js
+++ b/frontend/pages/api/nodes.js
@@ -5,7 +5,7 @@ export default async function(req, res) {
     await call(".node-telemetry", [
       {
         ...req.body,
-        ip_address: req.socket.remoteAddress
+        ip_address: req.headers["x-forwarded-for"] || req.socket.remoteAddress
       }
     ]);
   } catch (error) {


### PR DESCRIPTION
*Resolve #76*

This way we avoid logging load-balancer IP addresses instead of real ones.