### PR TITLE
Implemented Transaction Details Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # backend ignores
 backend/db
+
+# frontend ignores
+frontend/cypress/videos

--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -33,6 +33,10 @@ wampHandlers["nearcore-query"] = async ([path, data]) => {
   return await nearRpc.query(path, data);
 };
 
+wampHandlers["nearcore-tx"] = async ([transactionHash]) => {
+  return await nearRpc.sendJsonRpc("tx", [transactionHash]);
+};
+
 function setupWamp() {
   const wamp = new autobahn.Connection({
     realm: "near-explorer",

--- a/frontend/src/components/transactions/ReceiptRow.tsx
+++ b/frontend/src/components/transactions/ReceiptRow.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Row, Col } from "react-bootstrap";
+
+import * as T from "../../libraries/explorer-wamp/transactions";
+
+export interface Props {
+  receipt: T.Receipt;
+}
+
+export interface State {}
+
+export default class extends React.Component<Props, State> {
+  render() {
+    const { receipt } = this.props;
+
+    return (
+      <Row noGutters className="receipt-row mx-0">
+        <Col className="receipt-row-details">
+          <Row noGutters>
+            <Col md="8" xs="7">
+              <Row noGutters>
+                <Col className="receipt-row-title">
+                  {receipt.result.result === null ? (
+                    "No result"
+                  ) : receipt.result.result.length === 0 ? (
+                    "Empty result"
+                  ) : (
+                    <>
+                      <i>Result:</i> <pre>{receipt.result.result}</pre>
+                    </>
+                  )}
+                </Col>
+              </Row>
+              <Row noGutters>
+                <Col className="receipt-row-text">
+                  {receipt.result.logs.length === 0 ? (
+                    "No logs"
+                  ) : (
+                    <pre>{receipt.result.logs.join("\n")}</pre>
+                  )}
+                </Col>
+              </Row>
+            </Col>
+            <Col md="4" xs="5" className="ml-auto text-right">
+              <Row>
+                <Col className="receipt-row-receipt-hash">
+                  {`${receipt.hash.substr(0, 7)}...`}
+                </Col>
+              </Row>
+              <Row>
+                <Col className="receipt-row-status">
+                  {receipt.result.status}
+                </Col>
+              </Row>
+            </Col>
+          </Row>
+        </Col>
+        <style jsx global>{`
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 10px;
+            border-top: solid 2px #f8f8f8;
+          }
+
+          .receipt-row-bottom {
+            border-bottom: solid 2px #f8f8f8;
+          }
+
+          .receipt-row-title {
+            font-family: BentonSans;
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-family: BentonSans;
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-family: BentonSans;
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            color: #0072ce;
+          }
+
+          .receipt-row-status {
+            font-family: BentonSans;
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        `}</style>
+      </Row>
+    );
+  }
+}

--- a/frontend/src/components/transactions/ReceiptsList.tsx
+++ b/frontend/src/components/transactions/ReceiptsList.tsx
@@ -1,0 +1,15 @@
+import * as T from "../../libraries/explorer-wamp/transactions";
+
+import ReceiptRow from "./ReceiptRow";
+
+export interface Props {
+  receipts: T.Receipt[];
+}
+
+export default ({ receipts }: Props) => (
+  <>
+    {receipts.map(receipt => (
+      <ReceiptRow key={receipt.hash} receipt={receipt} />
+    ))}
+  </>
+);

--- a/frontend/src/components/transactions/TransactionDetails.tsx
+++ b/frontend/src/components/transactions/TransactionDetails.tsx
@@ -1,0 +1,92 @@
+import { Row, Col } from "react-bootstrap";
+
+import { Transaction } from "../../libraries/explorer-wamp/transactions";
+import moment from "../../libraries/moment";
+
+import AccountLink from "../utils/AccountLink";
+import BlockLink from "../utils/BlockLink";
+import CardCell from "../utils/CardCell";
+
+export interface Props {
+  transaction: Transaction;
+}
+
+export default ({ transaction }: Props) => {
+  return (
+    <div className="transaction-info-container">
+      <Row noGutters>
+        <Col md="5">
+          <CardCell
+            title="Signed by"
+            imgLink="/static/images/icon-m-user.svg"
+            text={<AccountLink accountId={transaction.signerId} />}
+            className="border-0"
+          />
+        </Col>
+        <Col md="5">
+          <CardCell
+            title="Receiver"
+            imgLink="/static/images/icon-m-user.svg"
+            text={<AccountLink accountId={transaction.receiverId} />}
+          />
+        </Col>
+        <Col md="2">
+          <CardCell
+            title="Status"
+            imgLink="/static/images/icon-m-filter.svg"
+            text={transaction.status}
+          />
+        </Col>
+      </Row>
+      <Row noGutters className="border-0">
+        <Col md="4">
+          <CardCell
+            title="Created"
+            text={moment(transaction.blockTimestamp).format(
+              "MMMM DD, YYYY [at] h:mm:ssa"
+            )}
+            className="border-0"
+          />
+        </Col>
+        <Col md="8">
+          <CardCell title="Hash" text={transaction.hash} className="border-0" />
+        </Col>
+      </Row>
+      <Row noGutters>
+        <Col md="12">
+          <CardCell
+            title="Block Hash"
+            text={
+              <BlockLink blockHash={transaction.blockHash}>
+                {transaction.blockHash}
+              </BlockLink>
+            }
+            className="transaction-card-block-hash border-0"
+          />
+        </Col>
+      </Row>
+      <style jsx global>{`
+        .transaction-info-container {
+          border: solid 4px #e6e6e6;
+          border-radius: 4px;
+        }
+
+        .transaction-info-container > .row {
+          border-bottom: 2px solid #e6e6e6;
+        }
+
+        .transaction-info-container > .row:last-of-type {
+          border-bottom: 0;
+        }
+
+        .transaction-info-container > .row:first-of-type .card-cell-text {
+          font-size: 24px;
+        }
+
+        .transaction-card-block-hash {
+          background-color: #f8f8f8;
+        }
+      `}</style>
+    </div>
+  );
+};

--- a/frontend/src/components/transactions/__tests__/ReceiptRow.test.tsx
+++ b/frontend/src/components/transactions/__tests__/ReceiptRow.test.tsx
@@ -1,0 +1,15 @@
+import renderer from "react-test-renderer";
+
+import ReceiptRow from "../ReceiptRow";
+
+import { TRANSACTIONS } from "./common";
+
+describe("<ReceiptRow />", () => {
+  it("renders", () => {
+    expect(
+      renderer.create(
+        <ReceiptRow receipt={(TRANSACTIONS[0].receipts || [])[0]} />
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/transactions/__tests__/ReceiptsList.test.tsx
+++ b/frontend/src/components/transactions/__tests__/ReceiptsList.test.tsx
@@ -1,0 +1,15 @@
+import renderer from "react-test-renderer";
+
+import ReceiptsList from "../ReceiptsList";
+
+import { TRANSACTIONS } from "./common";
+
+describe("<ReceiptsList />", () => {
+  it("renders", () => {
+    expect(
+      renderer.create(
+        <ReceiptsList receipts={TRANSACTIONS[0].receipts || []} />
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/transactions/__tests__/TransactionDetails.test.tsx
+++ b/frontend/src/components/transactions/__tests__/TransactionDetails.test.tsx
@@ -1,0 +1,13 @@
+import renderer from "react-test-renderer";
+
+import TransactionDetails from "../TransactionDetails";
+
+import { TRANSACTIONS } from "./common";
+
+describe("<TransactionDetails />", () => {
+  it("renders", () => {
+    expect(
+      renderer.create(<TransactionDetails transaction={TRANSACTIONS[0]} />)
+    ).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ReceiptRow /> renders 1`] = `
+<div
+  className="receipt-row mx-0 row no-gutters"
+>
+  <div
+    className="receipt-row-details col"
+  >
+    <div
+      className="row no-gutters"
+    >
+      <div
+        className="col-md-8 col-7"
+      >
+        <div
+          className="row no-gutters"
+        >
+          <div
+            className="receipt-row-title col"
+          >
+            No result
+          </div>
+        </div>
+        <div
+          className="row no-gutters"
+        >
+          <div
+            className="receipt-row-text col"
+          >
+            No logs
+          </div>
+        </div>
+      </div>
+      <div
+        className="ml-auto text-right col-md-4 col-5"
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="receipt-row-receipt-hash col"
+          >
+            9uZxS2c...
+          </div>
+        </div>
+        <div
+          className="row"
+        >
+          <div
+            className="receipt-row-status col"
+          >
+            Completed
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptsList.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptsList.test.tsx.snap
@@ -1,0 +1,178 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ReceiptsList /> renders 1`] = `
+Array [
+  <div
+    className="receipt-row mx-0 row no-gutters"
+  >
+    <div
+      className="receipt-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="receipt-row-title col"
+            >
+              No result
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="receipt-row-text col"
+            >
+              No logs
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="receipt-row-receipt-hash col"
+            >
+              9uZxS2c...
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="receipt-row-status col"
+            >
+              Completed
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="receipt-row mx-0 row no-gutters"
+  >
+    <div
+      className="receipt-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="receipt-row-title col"
+            >
+              Empty result
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="receipt-row-text col"
+            >
+              <pre
+                className="jsx-1146029612"
+              >
+                LOG: Counter is now: 1
+              </pre>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="receipt-row-receipt-hash col"
+            >
+              A8HaLh5...
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="receipt-row-status col"
+            >
+              Completed
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="receipt-row mx-0 row no-gutters"
+  >
+    <div
+      className="receipt-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="receipt-row-title col"
+            >
+              Empty result
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="receipt-row-text col"
+            >
+              No logs
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="receipt-row-receipt-hash col"
+            >
+              A5oSQ6z...
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="receipt-row-status col"
+            >
+              Completed
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/TransactionDetails.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/TransactionDetails.test.tsx.snap
@@ -1,0 +1,209 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TransactionDetails /> renders 1`] = `
+<div
+  className="jsx-2526461550 transaction-info-container"
+>
+  <div
+    className="row no-gutters"
+  >
+    <div
+      className="col-md-5"
+    >
+      <div
+        className="card-cell border-0 card"
+      >
+        <div
+          className="card-body"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="card-cell-title align-self-center col-md-12 col-auto"
+            >
+              <img
+                className="jsx-3005147464 card-cell-title-img"
+                src="/static/images/icon-m-user.svg"
+              />
+              Signed by
+            </div>
+            <div
+              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+            >
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="col-md-5"
+    >
+      <div
+        className="card-cell  card"
+      >
+        <div
+          className="card-body"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="card-cell-title align-self-center col-md-12 col-auto"
+            >
+              <img
+                className="jsx-3005147464 card-cell-title-img"
+                src="/static/images/icon-m-user.svg"
+              />
+              Receiver
+            </div>
+            <div
+              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+            >
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="col-md-2"
+    >
+      <div
+        className="card-cell  card"
+      >
+        <div
+          className="card-body"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="card-cell-title align-self-center col-md-12 col-auto"
+            >
+              <img
+                className="jsx-3005147464 card-cell-title-img"
+                src="/static/images/icon-m-filter.svg"
+              />
+              Status
+            </div>
+            <div
+              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+            >
+              Completed
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="border-0 row no-gutters"
+  >
+    <div
+      className="col-md-4"
+    >
+      <div
+        className="card-cell border-0 card"
+      >
+        <div
+          className="card-body"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="card-cell-title align-self-center col-md-12 col-auto"
+            >
+              Created
+            </div>
+            <div
+              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+            >
+              February 01, 2019 at 12:00:00am
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="col-md-8"
+    >
+      <div
+        className="card-cell border-0 card"
+      >
+        <div
+          className="card-body"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="card-cell-title align-self-center col-md-12 col-auto"
+            >
+              Hash
+            </div>
+            <div
+              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+            >
+              BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="row no-gutters"
+  >
+    <div
+      className="col-md-12"
+    >
+      <div
+        className="card-cell transaction-card-block-hash border-0 card"
+      >
+        <div
+          className="card-body"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="card-cell-title align-self-center col-md-12 col-auto"
+            >
+              Block Hash
+            </div>
+            <div
+              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+            >
+              <a
+                className="block-link"
+                href="/blocks/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/components/transactions/__tests__/common.tsx
+++ b/frontend/src/components/transactions/__tests__/common.tsx
@@ -24,6 +24,35 @@ export const TRANSACTIONS: T.Transaction[] = [
           public_key: "ed25519:8LXEySyBYewiTTLxjfF1TKDsxxxxxxxxxxxxxxxxxx"
         } as T.AddKey
       } as T.Action
+    ],
+    receipts: [
+      {
+        hash: "9uZxS2cuZv7yphcidRiwNqDayMxcVRE1zHkAmwrHr1vs",
+        result: {
+          logs: [],
+          receipts: ["A8HaLh5pzaeuiq4VVnmgghT6RzCRuiNftkJCZmVQvN3v"],
+          result: null,
+          status: "Completed"
+        }
+      },
+      {
+        hash: "A8HaLh5pzaeuiq4VVnmgghT6RzCRuiNftkJCZmVQvN3v",
+        result: {
+          logs: ["LOG: Counter is now: 1"],
+          receipts: ["A5oSQ6z71zWi3X1KFy9xhNzyjj8bQx4wwboWUMnK3dgp"],
+          result: "",
+          status: "Completed"
+        }
+      },
+      {
+        hash: "A5oSQ6z71zWi3X1KFy9xhNzyjj8bQx4wwboWUMnK3dgp",
+        result: {
+          logs: [],
+          receipts: [],
+          result: "",
+          status: "Completed"
+        }
+      }
     ]
   },
 
@@ -43,6 +72,7 @@ export const TRANSACTIONS: T.Transaction[] = [
           method_name: "addMessage"
         }
       } as T.Action
-    ]
+    ],
+    receipts: []
   }
 ];

--- a/frontend/src/pages/transactions/[hash].jsx
+++ b/frontend/src/pages/transactions/[hash].jsx
@@ -1,16 +1,52 @@
 import Head from "next/head";
 
+import React from "react";
+
+import TransactionIcon from "../../../public/static/images/icon-t-transactions.svg";
+
+import * as TransactionApi from "../../libraries/explorer-wamp/transactions";
+
+import ActionsList from "../../components/transactions/ActionsList";
+import TransactionDetails from "../../components/transactions/TransactionDetails";
+import Content from "../../components/utils/Content";
+
 export default class extends React.Component {
   static async getInitialProps({ query: { hash } }) {
-    return { hash };
+    try {
+      return await TransactionApi.getTransactionInfo(hash);
+    } catch (err) {
+      return { hash, err };
+    }
   }
 
   render() {
+    const { hash } = this.props;
     return (
       <>
         <Head>
-          <title>Near Explorer | Transactions</title>
+          <title>Near Explorer | Transaction</title>
         </Head>
+        <Content
+          title={
+            <h1>{`Transaction: ${hash.substring(0, 7)}...${hash.substring(
+              hash.length - 4
+            )}`}</h1>
+          }
+          border={false}
+        >
+          {this.props.err ? (
+            `Information is not available at the moment. Please, check if the transaction hash is correct or try later.`
+          ) : (
+            <TransactionDetails transaction={this.props} />
+          )}
+        </Content>
+        <Content
+          size="medium"
+          icon={<TransactionIcon style={{ width: "22px" }} />}
+          title={<h2>Actions</h2>}
+        >
+          <ActionsList actions={this.props.actions} transaction={this.props} />
+        </Content>
       </>
     );
   }

--- a/frontend/src/pages/transactions/[hash].jsx
+++ b/frontend/src/pages/transactions/[hash].jsx
@@ -7,6 +7,7 @@ import TransactionIcon from "../../../public/static/images/icon-t-transactions.s
 import * as TransactionApi from "../../libraries/explorer-wamp/transactions";
 
 import ActionsList from "../../components/transactions/ActionsList";
+import ReceiptsList from "../../components/transactions/ReceiptsList";
 import TransactionDetails from "../../components/transactions/TransactionDetails";
 import Content from "../../components/utils/Content";
 
@@ -46,6 +47,13 @@ export default class extends React.Component {
           title={<h2>Actions</h2>}
         >
           <ActionsList actions={this.props.actions} transaction={this.props} />
+        </Content>
+        <Content
+          size="medium"
+          icon={<TransactionIcon style={{ width: "22px" }} />}
+          title={<h2>Receipts</h2>}
+        >
+          <ReceiptsList receipts={this.props.receipts} />
         </Content>
       </>
     );


### PR DESCRIPTION
*Resolves #91*

Notes:

1. Transaction fees are not currently exposed via RPC, so we cannot show them yet. https://github.com/nearprotocol/nearcore/issues/1299
2. ~Action result and logs are not implemented yet, this is the only item left to be implemented.~
3. Mobile is ok, but we should definitely get back to it one day to review mobile readiness (including performance and network traffic size optimization) #111 
4. ~Tests are coming~
5. Links to the transaction details page from the dashboard, list of transactions, block details, account details pages work fine (in fact, those pages reuse the same component, so it was just a change in a single place)
6. Render.com deployment won't work for this PR as it introduces a change on the proxy-backend.

~Here is an example of a direct link to a transaction: https://near-explorer-frontend-pr-109.onrender.com/transactions/3dYfigPo3FGTb9rN2KhyXTXWrPsYaRDK69FTHW9So9Ff~

![image](https://user-images.githubusercontent.com/304265/67195959-9f39fb80-f402-11e9-8f63-70c4342b3e8b.png)
