### PR TITLE
Fixed actions ordering

### DIFF
--- a/frontend/src/components/dashboard/DashboardTransactions.jsx
+++ b/frontend/src/components/dashboard/DashboardTransactions.jsx
@@ -24,7 +24,11 @@ export default ({ transactions }) => (
         </div>
       </Col>
       <Col xs="11" className="px-0 dashboard-transactions-list">
-        <TransactionsList transactions={transactions} viewMode="compact" />
+        <TransactionsList
+          transactions={transactions}
+          viewMode="compact"
+          reversed
+        />
         <Row noGutters>
           <Col xs="1" className="dashboard-transactions-icon-col" />
           <Col xs="6">

--- a/frontend/src/components/transactions/ActionsList.tsx
+++ b/frontend/src/components/transactions/ActionsList.tsx
@@ -3,20 +3,25 @@ import * as T from "../../libraries/explorer-wamp/transactions";
 import ActionRow, { ViewMode } from "./ActionRow";
 
 export interface Props {
-  actions: T.Action[];
+  actions: (T.Action | keyof T.Action)[];
   transaction: T.Transaction;
   viewMode?: ViewMode;
+  reversed?: boolean;
 }
 
-export default ({ actions, transaction, viewMode }: Props) => (
-  <>
-    {actions.map((action, actionIndex) => (
-      <ActionRow
-        key={transaction.hash + actionIndex}
-        action={action}
-        transaction={transaction}
-        viewMode={viewMode}
-      />
-    ))}
-  </>
-);
+export default ({ actions, transaction, viewMode, reversed }: Props) => {
+  let actionRows = actions.map((action, actionIndex) => (
+    <ActionRow
+      key={transaction.hash + actionIndex}
+      action={action}
+      transaction={transaction}
+      viewMode={viewMode}
+    />
+  ));
+
+  if (reversed) {
+    actionRows.reverse();
+  }
+
+  return <>{actionRows}</>;
+};

--- a/frontend/src/components/transactions/Transactions.tsx
+++ b/frontend/src/components/transactions/Transactions.tsx
@@ -7,6 +7,8 @@ import TransactionsList from "./TransactionsList";
 export interface Props {
   accountId?: string;
   blockHash?: string;
+  reversed: boolean;
+  limit: number;
 }
 
 export interface State {
@@ -14,6 +16,11 @@ export interface State {
 }
 
 export default class extends React.PureComponent<Props, State> {
+  static defaultProps = {
+    reversed: false,
+    limit: 50
+  };
+
   state: State = {
     transactions: null
   };
@@ -22,8 +29,10 @@ export default class extends React.PureComponent<Props, State> {
     this.fetchTransactions();
   }
 
-  componentDidUpdate() {
-    this.fetchTransactions();
+  componentDidUpdate(prevProps: Props) {
+    if (this.props !== prevProps) {
+      this.fetchTransactions();
+    }
   }
 
   render() {
@@ -31,14 +40,21 @@ export default class extends React.PureComponent<Props, State> {
     if (transactions === null) {
       return null;
     }
-    return <TransactionsList transactions={transactions} />;
+    return (
+      <TransactionsList
+        transactions={transactions}
+        reversed={this.props.reversed}
+      />
+    );
   }
 
   fetchTransactions = async () => {
     const transactions = await TransactionsApi.getTransactions({
       signerId: this.props.accountId,
       receiverId: this.props.accountId,
-      blockHash: this.props.blockHash
+      blockHash: this.props.blockHash,
+      reversed: this.props.reversed,
+      limit: this.props.limit
     });
     this.setState({ transactions });
   };

--- a/frontend/src/components/transactions/TransactionsList.tsx
+++ b/frontend/src/components/transactions/TransactionsList.tsx
@@ -6,19 +6,23 @@ import { ViewMode } from "./ActionRow";
 export interface Props {
   transactions: T.Transaction[];
   viewMode?: ViewMode;
+  reversed?: boolean;
 }
 
-export default ({ transactions, viewMode }: Props) => {
-  return (
-    <>
-      {transactions.map(transaction => (
-        <ActionsList
-          key={transaction.hash}
-          actions={transaction.actions.reverse()}
-          transaction={transaction}
-          viewMode={viewMode}
-        />
-      ))}
-    </>
-  );
+export default ({ transactions, viewMode, reversed }: Props) => {
+  let actions = transactions.map(transaction => (
+    <ActionsList
+      key={transaction.hash}
+      actions={transaction.actions}
+      transaction={transaction}
+      viewMode={viewMode}
+      reversed={reversed}
+    />
+  ));
+
+  if (reversed) {
+    actions.reverse();
+  }
+
+  return <>{actions}</>;
 };

--- a/frontend/src/components/transactions/__tests__/ActionsList.test.tsx
+++ b/frontend/src/components/transactions/__tests__/ActionsList.test.tsx
@@ -27,4 +27,27 @@ describe("<ActionsList />", () => {
       )
     ).toMatchSnapshot();
   });
+
+  it("renders reversed", () => {
+    expect(
+      JSON.stringify(
+        renderer.create(
+          <ActionsList
+            transaction={TRANSACTIONS[0]}
+            actions={TRANSACTIONS[0].actions}
+            reversed
+          />
+        )
+      )
+    ).toEqual(
+      JSON.stringify(
+        renderer.create(
+          <ActionsList
+            transaction={TRANSACTIONS[0]}
+            actions={[...TRANSACTIONS[0].actions].reverse()}
+          />
+        )
+      )
+    );
+  });
 });

--- a/frontend/src/components/transactions/__tests__/TransactionsList.test.tsx
+++ b/frontend/src/components/transactions/__tests__/TransactionsList.test.tsx
@@ -10,4 +10,23 @@ describe("<TransactionsList />", () => {
       renderer.create(<TransactionsList transactions={TRANSACTIONS} />)
     ).toMatchSnapshot();
   });
+
+  it("renders reversed", () => {
+    const reversedTransactions = TRANSACTIONS.map(transaction => {
+      return { ...transaction, actions: [...transaction.actions].reverse() };
+    }).reverse();
+    expect(
+      JSON.stringify(
+        renderer.create(
+          <TransactionsList transactions={TRANSACTIONS} reversed />
+        )
+      )
+    ).toEqual(
+      JSON.stringify(
+        renderer.create(
+          <TransactionsList transactions={reversedTransactions} />
+        )
+      )
+    );
+  });
 });

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
@@ -1,5 +1,655 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ActionsList /> renders compact 1`] = `null`;
+exports[`<ActionsList /> renders compact 1`] = `
+Array [
+  <div
+    className="action-compact-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.26 9l-.34-.45a4.5 4.5 0 1 0-3.84 0L6.74 9A7 7 0 0 0 0 16v2h18v-2a7 7 0 0 0-6.74-7z"
+            fill="#0071ce"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              New account created: 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="action-compact-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 18l9-9-9-9zm18-9L9 0v18z"
+            fill="#8dd4bd"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              Transferred 10.00000 Ⓝ to 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="action-compact-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18 18v-3.6L8.92 5.32A4.5 4.5 0 1 0 4.5 9a4.47 4.47 0 0 0 .82-.08L14.4 18zM3 4.5A1.5 1.5 0 1 1 4.5 6 1.5 1.5 0 0 1 3 4.5z"
+            fill="#5ace84"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              New key added for 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+              : ed25519:8LXEySy...
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
 
-exports[`<ActionsList /> renders sparsely by default 1`] = `null`;
+exports[`<ActionsList /> renders sparsely by default 1`] = `
+Array [
+  <div
+    className="action-sparse-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.26 9l-.34-.45a4.5 4.5 0 1 0-3.84 0L6.74 9A7 7 0 0 0 0 16v2h18v-2a7 7 0 0 0-6.74-7z"
+            fill="#0071ce"
+          />
+        </svg>
+      </div>
+      <img
+        className="jsx-2315684868 action-row-toggler"
+        src="/static/images/icon-arrow-right.svg"
+      />
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              New account created: 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="action-sparse-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 18l9-9-9-9zm18-9L9 0v18z"
+            fill="#8dd4bd"
+          />
+        </svg>
+      </div>
+      <img
+        className="jsx-2315684868 action-row-toggler"
+        src="/static/images/icon-arrow-right.svg"
+      />
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              Transferred 10.00000 Ⓝ to 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="action-sparse-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18 18v-3.6L8.92 5.32A4.5 4.5 0 1 0 4.5 9a4.47 4.47 0 0 0 .82-.08L14.4 18zM3 4.5A1.5 1.5 0 1 1 4.5 6 1.5 1.5 0 0 1 3 4.5z"
+            fill="#5ace84"
+          />
+        </svg>
+      </div>
+      <img
+        className="jsx-2315684868 action-row-toggler"
+        src="/static/images/icon-arrow-right.svg"
+      />
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              New key added for 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+              : ed25519:8LXEySy...
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/TransactionsList.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/TransactionsList.test.tsx.snap
@@ -1,3 +1,443 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<TransactionsList /> renders 1`] = `null`;
+exports[`<TransactionsList /> renders 1`] = `
+Array [
+  <div
+    className="action-sparse-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.26 9l-.34-.45a4.5 4.5 0 1 0-3.84 0L6.74 9A7 7 0 0 0 0 16v2h18v-2a7 7 0 0 0-6.74-7z"
+            fill="#0071ce"
+          />
+        </svg>
+      </div>
+      <img
+        className="jsx-2315684868 action-row-toggler"
+        src="/static/images/icon-arrow-right.svg"
+      />
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              New account created: 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="action-sparse-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 18l9-9-9-9zm18-9L9 0v18z"
+            fill="#8dd4bd"
+          />
+        </svg>
+      </div>
+      <img
+        className="jsx-2315684868 action-row-toggler"
+        src="/static/images/icon-arrow-right.svg"
+      />
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              Transferred 10.00000 Ⓝ to 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="action-sparse-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18 18v-3.6L8.92 5.32A4.5 4.5 0 1 0 4.5 9a4.47 4.47 0 0 0 .82-.08L14.4 18zM3 4.5A1.5 1.5 0 1 1 4.5 6 1.5 1.5 0 0 1 3 4.5z"
+            fill="#5ace84"
+          />
+        </svg>
+      </div>
+      <img
+        className="jsx-2315684868 action-row-toggler"
+        src="/static/images/icon-arrow-right.svg"
+      />
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              New key added for 
+              <a
+                className="account-link"
+                href="/accounts/receiver.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver.test
+              </a>
+              : ed25519:8LXEySy...
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                BvJeW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="action-sparse-row mx-0  row no-gutters"
+  >
+    <div
+      className="actions-icon-col col-auto"
+    >
+      <div
+        className="jsx-2315684868 action-row-img"
+      >
+        <svg
+          className="jsx-2315684868"
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 9l6 6L9 0zm12-6L9 18l9-9z"
+            fill="#ccc"
+          />
+        </svg>
+      </div>
+      <img
+        className="jsx-2315684868 action-row-toggler"
+        src="/static/images/icon-arrow-right.svg"
+      />
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-8 col-7"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-title col"
+            >
+              Called method in contract: 
+              <a
+                className="account-link"
+                href="/accounts/receiver2.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @receiver2.test
+              </a>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by 
+              <a
+                className="account-link"
+                href="/accounts/signer2.test"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                @signer2.test
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ml-auto text-right col-md-4 col-5"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-txid col"
+            >
+              <a
+                className="transaction-link"
+                href="/transactions/222eW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                222eW6g...
+              </a>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="jsx-2315684868 action-row-timer-status"
+              >
+                Completed
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/frontend/src/components/transactions/__tests__/common.tsx
+++ b/frontend/src/components/transactions/__tests__/common.tsx
@@ -1,4 +1,6 @@
-export const TRANSACTIONS = [
+import * as T from "../../../libraries/explorer-wamp/transactions";
+
+export const TRANSACTIONS: T.Transaction[] = [
   {
     hash: "BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj",
     signerId: "signer.test",
@@ -6,6 +8,41 @@ export const TRANSACTIONS = [
     status: "Completed",
     blockHash: "BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj",
     blockTimestamp: +new Date(2019, 1, 1),
-    actions: []
+    actions: [
+      "CreateAccount" as keyof T.Action,
+      {
+        Transfer: {
+          deposit: "10000000000000000000"
+        } as T.Transfer
+      } as T.Action,
+      {
+        AddKey: {
+          access_key: {
+            nonce: 0,
+            permission: "FullAccess"
+          },
+          public_key: "ed25519:8LXEySyBYewiTTLxjfF1TKDsxxxxxxxxxxxxxxxxxx"
+        } as T.AddKey
+      } as T.Action
+    ]
+  },
+
+  {
+    hash: "222eW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj",
+    signerId: "signer2.test",
+    receiverId: "receiver2.test",
+    status: "Completed",
+    blockHash: "222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj",
+    blockTimestamp: +new Date(2019, 1, 1),
+    actions: [
+      {
+        FunctionCall: {
+          args: "eyJ0ZXh0Ijoid2hlbiBpY28/In0=",
+          deposit: "0",
+          gas: 2000000,
+          method_name: "addMessage"
+        }
+      } as T.Action
+    ]
   }
 ];

--- a/frontend/src/pages/accounts/[id].jsx
+++ b/frontend/src/pages/accounts/[id].jsx
@@ -37,7 +37,7 @@ export default class extends React.Component {
           icon={<TransactionIcon style={{ width: "22px" }} />}
           title={<h2>Transactions</h2>}
         >
-          <Transactions accountId={this.props.id} />
+          <Transactions accountId={this.props.id} reversed />
         </Content>
       </>
     );

--- a/frontend/src/pages/transactions/index.jsx
+++ b/frontend/src/pages/transactions/index.jsx
@@ -11,7 +11,7 @@ export default class extends React.Component {
           <title>Near Explorer | Transactions</title>
         </Head>
         <Content title={<h1>Transactions</h1>}>
-          <Transactions />
+          <Transactions reversed />
         </Content>
       </>
     );


### PR DESCRIPTION
I have assumed that `Array.reverse()` was not in-place (which turned out to be a wrong assumption). I have initially started with a simple fix changing `actions.reverse()` to `[...actions].reverse()`, but then I wanted to avoid shallow copies of the arrays and decided to reverse the components instead of the input arrays.

Another item that is fixed now is the order of actions on the Transaction Details page (they used to be in a reverse order, which does not make a lot of sense from the user perspective), and the order of transactions/actions on the Block Details page (the same reasoning).