### PR TITLE
Fixed PRs deployment on render.com

### DIFF
--- a/frontend/src/components/utils/DataProvider.tsx
+++ b/frontend/src/components/utils/DataProvider.tsx
@@ -1,10 +1,12 @@
 import { createContext } from "react";
 
+import { NearNetwork } from "../../libraries/config";
+
 const DataContext = createContext({});
 
 export interface Props {
-  currentNearNetwork: any;
-  nearNetworks: any;
+  currentNearNetwork: NearNetwork;
+  nearNetworks: [NearNetwork];
   children: React.ReactNode;
 }
 

--- a/frontend/src/libraries/config.ts
+++ b/frontend/src/libraries/config.ts
@@ -1,0 +1,19 @@
+import getConfig from "next/config";
+
+const {
+  publicRuntimeConfig: { nearNetworks, nearNetworkAliases }
+} = getConfig();
+
+export interface NearNetwork {
+  name: string;
+  explorerLink: string;
+  aliases: [string];
+}
+
+export function getNearNetwork(hostname: string): NearNetwork {
+  let nearNetwork = nearNetworkAliases[hostname];
+  if (nearNetwork === undefined) {
+    nearNetwork = nearNetworks[0];
+  }
+  return nearNetwork;
+}

--- a/frontend/src/libraries/explorer-wamp/index.ts
+++ b/frontend/src/libraries/explorer-wamp/index.ts
@@ -2,6 +2,8 @@ import getConfig from "next/config";
 
 import autobahn from "autobahn";
 
+import { getNearNetwork } from "../config";
+
 interface IPromisePair {
   resolve: (value?: autobahn.Session) => void;
   reject: (value?: string) => void;
@@ -40,6 +42,11 @@ export class ExplorerApi {
     }
 
     if (apiPrefixSource === undefined) {
+      if (typeof location === "undefined") {
+        throw Error(
+          "DevHint: You must provide `apiPrefixSource` argument to Explorer API constructor if you instantiate it on the server side."
+        );
+      }
       this.apiPrefix = location.host;
     } else if (typeof apiPrefixSource === "string") {
       this.apiPrefix = apiPrefixSource;
@@ -51,10 +58,7 @@ export class ExplorerApi {
       );
     }
 
-    const { nearNetworkAliases } = publicRuntimeConfig;
-    if (this.apiPrefix in nearNetworkAliases) {
-      this.apiPrefix = nearNetworkAliases[this.apiPrefix].name;
-    }
+    this.apiPrefix = getNearNetwork(this.apiPrefix).name;
   }
 
   // Establish and handle concurrent requests to establish WAMP connection.

--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -7,11 +7,12 @@ import { Container } from "react-bootstrap";
 import Header from "../components/utils/Header";
 import Footer from "../components/utils/Footer";
 import DataProvider from "../components/utils/DataProvider";
+import { getNearNetwork } from "../libraries/config";
 
 import "bootstrap/dist/css/bootstrap.min.css";
 
 const {
-  publicRuntimeConfig: { nearNetworks, nearNetworkAliases, googleAnalytics }
+  publicRuntimeConfig: { nearNetworks, googleAnalytics }
 } = getConfig();
 
 export default class extends App {
@@ -29,9 +30,9 @@ export default class extends App {
 
     let currentNearNetwork;
     if (typeof window === "undefined") {
-      currentNearNetwork = nearNetworkAliases[appContext.ctx.req.headers.host];
+      currentNearNetwork = getNearNetwork(appContext.ctx.req.headers.host);
     } else {
-      currentNearNetwork = nearNetworkAliases[window.location.host];
+      currentNearNetwork = getNearNetwork(window.location.host);
     }
     return {
       currentNearNetwork,


### PR DESCRIPTION
It was a multi-network compatibility issue. The domain names of the render.com deployments (e.g. `near-explorer-frontend-pr-133.onrender.com`) do not match any of the networks. The fix just falls back any unknown domain to the first configured network.