### PR TITLE
fix: Hotfixing a broken Explorer due to the huge args to FunctionCall which we tried to save to the DB

### DIFF
--- a/backend/src/sync.js
+++ b/backend/src/sync.js
@@ -72,6 +72,8 @@ async function saveBlocks(blocksInfo) {
                       }
                       if (action.DeployContract !== undefined) {
                         delete action.DeployContract.code;
+                      } else if (action.FunctionCall !== undefined) {
+                        delete action.FunctionCall.args;
                       }
                       return action;
                     });


### PR DESCRIPTION
NOTE: We should query this information on the frontend from the node on demand.