### PR TITLE
fix: Added hex view for the contract arguments

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -4,3 +4,5 @@ declare module "*.svg" {
   const content: React.FC;
   export default content;
 }
+
+declare module "react-text-collapse";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6124,6 +6124,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hexy": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.0.tgz",
+      "integrity": "sha512-+pMQUQCkl1DQ/Im/Y3wixzIr2j8+o8gRIcB3Dw5n5kcbPwPGEEde9hfX3HzRzR00pS/8NmSohSvYnhBs0jA4hw=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -10263,8 +10268,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.1",
@@ -12707,7 +12711,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -12885,6 +12888,23 @@
         }
       }
     },
+    "react-motion": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
+      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
+      "requires": {
+        "performance-now": "^0.2.0",
+        "prop-types": "^15.5.8",
+        "raf": "^3.1.0"
+      },
+      "dependencies": {
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        }
+      }
+    },
     "react-overlays": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-2.1.0.tgz",
@@ -12909,6 +12929,14 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.18.0"
+      }
+    },
+    "react-text-collapse": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-text-collapse/-/react-text-collapse-0.5.2.tgz",
+      "integrity": "sha512-CNPyXGUWfSZzuCgc9TExeOopEXgam3cVV0/avmcSXguTkdul3NOAEs3/DucweU2edApNPYfN3PlQEzkkbC7XpA==",
+      "requires": {
+        "prop-types": "^15.5.10"
       }
     },
     "react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "@zeit/next-css": "^1.0.1",
     "autobahn": "19.7.3",
     "bootstrap": "^4.3.1",
+    "hexy": "^0.3.0",
     "moment": "^2.24.0",
     "nearlib": "^0.19.1",
     "next": "^9.1.0",
@@ -47,6 +48,8 @@
     "react-dom": "^16.10.2",
     "react-flip-move": "^3.0.3",
     "react-loading-overlay": "^1.0.1",
+    "react-motion": "^0.5.2",
+    "react-text-collapse": "^0.5.2",
     "styled-components": "^4.4.0"
   },
   "devDependencies": {

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionMessage.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionMessage.test.tsx.snap
@@ -72,12 +72,46 @@ Array [
   >
     @receiver2.test
   </a>,
-  "Arguments in method: ",
-  <pre>
-     
-    {"text":"when ico?"}
-     
-  </pre>,
+  <dl>
+    <dt>
+      Arguments:
+    </dt>
+    <dd>
+      <div>
+        <div
+          style={
+            Object {
+              "display": "block",
+              "height": "0px",
+              "overflow": "hidden",
+            }
+          }
+        >
+          <textarea
+            className="jsx-3751390317 code-preview"
+            readOnly={true}
+          >
+            {
+  "text": "when ico?"
+}
+          </textarea>
+        </div>
+        <div
+          onClick={[Function]}
+        >
+          <div
+            style={
+              Object {
+                "float": "left",
+              }
+            }
+          >
+            Show more
+          </div>
+        </div>
+      </div>
+    </dd>
+  </dl>,
 ]
 `;
 

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionRow.test.tsx.snap
@@ -152,12 +152,46 @@ exports[`<ActionRow /> renders functioncall with detail 1`] = `
             >
               @receiver.test
             </a>
-            Arguments in method: 
-            <pre>
-               
-              {"value":1}
-               
-            </pre>
+            <dl>
+              <dt>
+                Arguments:
+              </dt>
+              <dd>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "display": "block",
+                        "height": "0px",
+                        "overflow": "hidden",
+                      }
+                    }
+                  >
+                    <textarea
+                      className="jsx-3751390317 code-preview"
+                      readOnly={true}
+                    >
+                      {
+  "value": 1
+}
+                    </textarea>
+                  </div>
+                  <div
+                    onClick={[Function]}
+                  >
+                    <div
+                      style={
+                        Object {
+                          "float": "left",
+                        }
+                      }
+                    >
+                      Show more
+                    </div>
+                  </div>
+                </div>
+              </dd>
+            </dl>
           </div>
         </div>
         <div

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
@@ -363,12 +363,46 @@ exports[`<ActionsList /> renders functioncall by default 1`] = `
             >
               @receiver2.test
             </a>
-            Arguments in method: 
-            <pre>
-               
-              {"text":"when ico?"}
-               
-            </pre>
+            <dl>
+              <dt>
+                Arguments:
+              </dt>
+              <dd>
+                <div>
+                  <div
+                    style={
+                      Object {
+                        "display": "block",
+                        "height": "0px",
+                        "overflow": "hidden",
+                      }
+                    }
+                  >
+                    <textarea
+                      className="jsx-3751390317 code-preview"
+                      readOnly={true}
+                    >
+                      {
+  "text": "when ico?"
+}
+                    </textarea>
+                  </div>
+                  <div
+                    onClick={[Function]}
+                  >
+                    <div
+                      style={
+                        Object {
+                          "float": "left",
+                        }
+                      }
+                    >
+                      Show more
+                    </div>
+                  </div>
+                </div>
+              </dd>
+            </dl>
           </div>
         </div>
         <div

--- a/frontend/src/components/utils/CodePreview.tsx
+++ b/frontend/src/components/utils/CodePreview.tsx
@@ -1,0 +1,35 @@
+import ReactTextCollapse from "react-text-collapse";
+
+export interface CollapseOptions {
+  collapseText: string;
+  expandText: string;
+  minHeight: number;
+  maxHeight: number;
+}
+
+export interface Props {
+  collapseOptions: CollapseOptions;
+  children: React.ReactNode;
+}
+
+export default (props: Props) => {
+  return (
+    <>
+      <ReactTextCollapse options={props.collapseOptions}>
+        <textarea readOnly className="code-preview">
+          {props.children}
+        </textarea>
+      </ReactTextCollapse>
+      <style jsx>{`
+        .code-preview {
+          font-family: mono;
+          background: #282c34;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      `}</style>
+    </>
+  );
+};

--- a/frontend/src/libraries/explorer-wamp/transactions.ts
+++ b/frontend/src/libraries/explorer-wamp/transactions.ts
@@ -162,9 +162,12 @@ export default class TransactionsApi extends ExplorerApi {
             transactionExtraInfo.status
           )[0] as ExecutionStatus;
 
-          try {
-            transaction.actions = JSON.parse(transaction.actions as string);
-          } catch {}
+          // Given we already queried the information from the node, we can use the actions,
+          // since DeployContract.code and FunctionCall.args are stripped away due to their size.
+          //
+          // Once the above TODO is resolved, we should just move this to TransactionInfo method
+          // (i.e. query the information there only for the specific transaction).
+          transaction.actions = transactionExtraInfo.transaction.actions;
         })
       );
       return transactions as Transaction[];


### PR DESCRIPTION
*Resolves #181*

# Test plan

The unit-tests are updated and no extra coverage is required at the moment.

I want to push these changes ASAP to resolve the broken Explorer state.

P.S. `hexdump-nodejs` (suggested by Vlad Grichina) did not play well with ES6 imports.