### PR TITLE
fix(frontend): Fixed React warning about textarea usage

### DIFF
--- a/frontend/src/components/transactions/ActionMessage.tsx
+++ b/frontend/src/components/transactions/ActionMessage.tsx
@@ -76,9 +76,10 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
           prettyArgs = hexy(decodedArgs, { format: "twos" });
         }
         args = (
-          <CodePreview collapseOptions={COLLAPSE_ARGS_OPTIONS}>
-            {prettyArgs}
-          </CodePreview>
+          <CodePreview
+            collapseOptions={COLLAPSE_ARGS_OPTIONS}
+            value={prettyArgs}
+          />
         );
       }
     }
@@ -147,5 +148,7 @@ export default (props: Props<AnyAction>) => {
       </>
     );
   }
-  return <MessageRenderer {...props as any} showDetails={props.showDetails} />;
+  return (
+    <MessageRenderer {...(props as any)} showDetails={props.showDetails} />
+  );
 };

--- a/frontend/src/components/transactions/ActionMessage.tsx
+++ b/frontend/src/components/transactions/ActionMessage.tsx
@@ -148,7 +148,5 @@ export default (props: Props<AnyAction>) => {
       </>
     );
   }
-  return (
-    <MessageRenderer {...(props as any)} showDetails={props.showDetails} />
-  );
+  return <MessageRenderer {...props as any} showDetails={props.showDetails} />;
 };

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionMessage.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionMessage.test.tsx.snap
@@ -90,11 +90,10 @@ Array [
           <textarea
             className="jsx-3751390317 code-preview"
             readOnly={true}
-          >
-            {
-  "text": "when ico?"
-}
-          </textarea>
+            value="{
+  \\"text\\": \\"when ico?\\"
+}"
+          />
         </div>
         <div
           onClick={[Function]}

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionRow.test.tsx.snap
@@ -171,11 +171,10 @@ exports[`<ActionRow /> renders functioncall with detail 1`] = `
                     <textarea
                       className="jsx-3751390317 code-preview"
                       readOnly={true}
-                    >
-                      {
-  "value": 1
-}
-                    </textarea>
+                      value="{
+  \\"value\\": 1
+}"
+                    />
                   </div>
                   <div
                     onClick={[Function]}

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
@@ -277,11 +277,10 @@ exports[`<ActionsList /> renders functioncall by default 1`] = `
                     <textarea
                       className="jsx-3751390317 code-preview"
                       readOnly={true}
-                    >
-                      {
-  "text": "when ico?"
-}
-                    </textarea>
+                      value="{
+  \\"text\\": \\"when ico?\\"
+}"
+                    />
                   </div>
                   <div
                     onClick={[Function]}

--- a/frontend/src/components/utils/CodePreview.tsx
+++ b/frontend/src/components/utils/CodePreview.tsx
@@ -9,16 +9,14 @@ export interface CollapseOptions {
 
 export interface Props {
   collapseOptions: CollapseOptions;
-  children: React.ReactNode;
+  value: string;
 }
 
 export default (props: Props) => {
   return (
     <>
       <ReactTextCollapse options={props.collapseOptions}>
-        <textarea readOnly className="code-preview">
-          {props.children}
-        </textarea>
+        <textarea readOnly className="code-preview" value={props.value} />
       </ReactTextCollapse>
       <style jsx>{`
         .code-preview {


### PR DESCRIPTION
> Warning: Use the `defaultValue` or `value` props instead of setting children on <textarea>.