### PR TITLE
fix: Backend should parse some environment variables (config values) as integers

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,11 +1,15 @@
 exports.nearRpcUrl = process.env.NEAR_RPC_URL || "http://localhost:3030";
-exports.syncFetchQueueSize = process.env.NEAR_SYNC_FETCH_QUEUE_SIZE || 3;
-exports.syncSaveQueueSize = process.env.NEAR_SYNC_SAVE_QUEUE_SIZE || 10;
-exports.bulkDbUpdateSize = process.env.NEAR_SYNC_BULK_DB_UPDATE_SIZE || 10;
+exports.syncFetchQueueSize =
+  parseInt(process.env.NEAR_SYNC_FETCH_QUEUE_SIZE) || 3;
+exports.syncSaveQueueSize =
+  parseInt(process.env.NEAR_SYNC_SAVE_QUEUE_SIZE) || 10;
+exports.bulkDbUpdateSize =
+  parseInt(process.env.NEAR_SYNC_BULK_DB_UPDATE_SIZE) || 10;
 exports.regularSyncNewNearcoreStateInterval =
-  process.env.NEAR_REGULAR_SYNC_NEW_NEARCORE_STATE_INTERVAL || 5000;
+  parseInt(process.env.NEAR_REGULAR_SYNC_NEW_NEARCORE_STATE_INTERVAL) || 5000;
 exports.regularSyncMissingNearcoreStateInterval =
-  process.env.NEAR_REGULAR_SYNC_MISSING_NEARCORE_STATE_INTERVAL || 60000;
+  parseInt(process.env.NEAR_REGULAR_SYNC_MISSING_NEARCORE_STATE_INTERVAL) ||
+  60000;
 
 exports.wampNearNetworkName =
   process.env.WAMP_NEAR_NETWORK_NAME || "localhostnet";

--- a/backend/src/sync.js
+++ b/backend/src/sync.js
@@ -6,7 +6,7 @@ const {
   bulkDbUpdateSize
 } = require("./config");
 const { nearRpc } = require("./near");
-const { Result } = require("./utils");
+const { Result, delayFor } = require("./utils");
 
 async function saveBlocks(blocksInfo) {
   try {
@@ -175,6 +175,7 @@ async function saveBlocksFromRequests(requests) {
               } catch (error) {
                 fetchError = error;
                 if (error.type === "system") {
+                  await delayFor(100 + Math.random() * 1000);
                   continue;
                 }
                 console.error(
@@ -219,10 +220,10 @@ async function syncNearcoreBlocks(topBlockHeight, bottomBlockHeight) {
       promiseResult(nearRpc.block(syncingBlockHeight))
     ]);
     --syncingBlockHeight;
-    if (requests.length > syncFetchQueueSize) {
+    if (requests.length >= syncFetchQueueSize) {
       saves.push(saveBlocksFromRequests(requests.splice(0, bulkDbUpdateSize)));
     }
-    if (saves.length > syncSaveQueueSize) {
+    if (saves.length >= syncSaveQueueSize) {
       await saves.shift();
     }
   }

--- a/backend/src/utils.js
+++ b/backend/src/utils.js
@@ -9,4 +9,8 @@ class Result {
   }
 }
 
+function delayFor(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
 exports.Result = Result;


### PR DESCRIPTION
"Fortunately", JS is fine comparing `12 < "13"` and somehow giving `true`, so the config options were respected if they were valid numbers.

I have also fixed a one-off check for the configuration options leading to one more extra item allowance over the limit.

Added some delay between chunks fetching retries.

## Test Plan

* [x] Manually checked that the config options are respected
* [x] Manually checked that passing non-integer value to the environment variables lead to using the default value