### PR TITLE
feature: Removed the deprecated storage_paid_at field

### DIFF
--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -5,53 +5,32 @@ import React from "react";
 import { Row, Col } from "react-bootstrap";
 
 import * as A from "../../libraries/explorer-wamp/accounts";
-import BlocksApi from "../../libraries/explorer-wamp/blocks";
 
 import Balance from "../utils/Balance";
 import CardCell from "../utils/CardCell";
 import TransactionLink from "../utils/TransactionLink";
-import BlockLink from "../utils/BlockLink";
 
 export interface Props {
   account: A.Account;
 }
 
-interface State {
-  storagePaidAtBlockHash: string | null;
-}
-
-export default class extends React.Component<Props, State> {
-  state: State = {
-    storagePaidAtBlockHash: null
-  };
-
-  fetchBlockHash = async (height: string) => {
-    new BlocksApi()
-      .getBlockInfo(height)
-      .then(block => this.setState({ storagePaidAtBlockHash: block.hash }))
-      .catch(err => console.error(err));
-  };
-
-  componentDidUpdate(preProps: Props) {
-    if (this.props.account !== preProps.account) {
-      this.fetchBlockHash(this.props.account.storagePaidAt.toString());
-    }
-  }
-  componentDidMount() {
-    this.fetchBlockHash(this.props.account.storagePaidAt.toString());
-  }
-
+export default class extends React.Component<Props> {
   render() {
     const { account } = this.props;
-    const { storagePaidAtBlockHash } = this.state;
     return (
       <div className="account-info-container">
         <Row noGutters>
-          <Col md="2">
+          <Col md="3">
             <CardCell
               title="Ⓝ Balance"
               text={<Balance amount={account.amount} />}
               className="border-0"
+            />
+          </Col>
+          <Col md="3">
+            <CardCell
+              title="Ⓝ Locked"
+              text={<Balance amount={account.locked} />}
             />
           </Col>
           <Col md="3">
@@ -71,33 +50,11 @@ export default class extends React.Component<Props, State> {
               }
             />
           </Col>
-          <Col md="2">
-            <CardCell
-              title="Locked"
-              imgLink="/static/images/icon-m-filter.svg"
-              text={<Balance amount={account.locked} />}
-            />
-          </Col>
           <Col md="3">
             <CardCell
-              title="Storage Used (Bytes)"
+              title="Storage Used"
               imgLink="/static/images/icon-storage.svg"
               text={`${account.storageUsage.toLocaleString()} B`}
-            />
-          </Col>
-          <Col md="2">
-            <CardCell
-              title="Last Paid"
-              imgLink="/static/images/icon-m-block.svg"
-              text={
-                storagePaidAtBlockHash !== null ? (
-                  <BlockLink blockHash={storagePaidAtBlockHash}>
-                    {`#${account.storagePaidAt.toLocaleString()}`}
-                  </BlockLink>
-                ) : (
-                  `#${account.storagePaidAt.toLocaleString()}`
-                )
-              }
             />
           </Col>
         </Row>

--- a/frontend/src/components/accounts/__tests__/__snapshots__/AccountDetails.test.tsx.snap
+++ b/frontend/src/components/accounts/__tests__/__snapshots__/AccountDetails.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<AccountDetails /> renders 1`] = `
     className="row no-gutters"
   >
     <div
-      className="col-md-2"
+      className="col-md-3"
     >
       <div
         className="card-cell border-0 card"
@@ -23,6 +23,40 @@ exports[`<AccountDetails /> renders 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               Ⓝ Balance
+            </div>
+            <div
+              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+            >
+              <span
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+              >
+                &lt;0.00001
+                 Ⓝ
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="col-md-3"
+    >
+      <div
+        className="card-cell  card"
+      >
+        <div
+          className="card-body"
+        >
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="card-cell-title align-self-center col-md-12 col-auto"
+            >
+              Ⓝ Locked
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
@@ -84,44 +118,6 @@ exports[`<AccountDetails /> renders 1`] = `
       </div>
     </div>
     <div
-      className="col-md-2"
-    >
-      <div
-        className="card-cell  card"
-      >
-        <div
-          className="card-body"
-        >
-          <div
-            className="row no-gutters"
-          >
-            <div
-              className="card-cell-title align-self-center col-md-12 col-auto"
-            >
-              <img
-                className="jsx-3005147464 card-cell-title-img"
-                src="/static/images/icon-m-filter.svg"
-              />
-              Locked
-            </div>
-            <div
-              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-            >
-              <span
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-              >
-                &lt;0.00001
-                 Ⓝ
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
       className="col-md-3"
     >
       <div
@@ -140,42 +136,12 @@ exports[`<AccountDetails /> renders 1`] = `
                 className="jsx-3005147464 card-cell-title-img"
                 src="/static/images/icon-storage.svg"
               />
-              Storage Used (Bytes)
+              Storage Used
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               0 B
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="col-md-2"
-    >
-      <div
-        className="card-cell  card"
-      >
-        <div
-          className="card-body"
-        >
-          <div
-            className="row no-gutters"
-          >
-            <div
-              className="card-cell-title align-self-center col-md-12 col-auto"
-            >
-              <img
-                className="jsx-3005147464 card-cell-title-img"
-                src="/static/images/icon-m-block.svg"
-              />
-              Last Paid
-            </div>
-            <div
-              className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-            >
-              #1
             </div>
           </div>
         </div>


### PR DESCRIPTION
As per the switch from State renting to State staking, `storage_paid_at` is no longer useful. Thus, removing it from the UI. https://github.com/nearprotocol/nearcore/issues/2271

## Test Plan

No extra tests are needed.