### PR TITLE
feat(backend): Added an index on transactions.block_timestamp

### DIFF
--- a/backend/models/Transaction.js
+++ b/backend/models/Transaction.js
@@ -43,6 +43,7 @@ module.exports = (sequelize, DataTypes) => {
       timestamps: false,
       indexes: [
         { fields: ["block_hash"] },
+        { fields: ["block_timestamp"] },
         { fields: ["signer_id"] },
         { fields: ["receiver_id"] }
       ]


### PR DESCRIPTION
Thanks @icerove for catching this out!

This improved the queries' performance even further (for obvious reasons...)