### PR TITLE
fix frontend and add indexes to account

### DIFF
--- a/backend/models/Account.js
+++ b/backend/models/Account.js
@@ -9,8 +9,8 @@ module.exports = (sequelize, DataTypes) => {
         primaryKey: true
       },
       accountIndex: {
-        type:DataTypes.BIGINT,
-        allowNull:false
+        type: DataTypes.BIGINT,
+        allowNull: false
       },
       createdByTransactionHash: {
         type: DataTypes.STRING, // base58

--- a/backend/models/Account.js
+++ b/backend/models/Account.js
@@ -8,6 +8,10 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         primaryKey: true
       },
+      accountIndex: {
+        type:DataTypes.BIGINT,
+        allowNull:false
+      },
       createdByTransactionHash: {
         type: DataTypes.STRING, // base58
         allowNull: false
@@ -20,7 +24,8 @@ module.exports = (sequelize, DataTypes) => {
     {
       tableName: "accounts",
       underscored: true,
-      timestamps: false
+      timestamps: false,
+      indexes: [{ fields: ["accountIndex"] }]
     }
   );
   Account.associate = function(models) {

--- a/backend/models/Account.js
+++ b/backend/models/Account.js
@@ -25,7 +25,10 @@ module.exports = (sequelize, DataTypes) => {
       tableName: "accounts",
       underscored: true,
       timestamps: false,
-      indexes: [{ fields: ["accountIndex"] }]
+      indexes: [
+        { fields: ["account_index"] },
+        { fields: ["created_at_block_timestamp"] }
+      ]
     }
   );
   Account.associate = function(models) {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/nearprotocol/near-explorer#readme",
   "dependencies": {
     "autobahn": "19.4.1",
+    "moment": "^2.24.0",
     "nearlib": "^0.18.0",
     "sequelize": "^5.21.1",
     "sqlite3": "^4.1.0",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,9 +2,13 @@ const models = require("../models");
 
 const {
   regularSyncNewNearcoreStateInterval,
-  regularSyncMissingNearcoreStateInterval,
+  regularSyncMissingNearcoreStateInterval
 } = require("./config");
-const { syncNewNearcoreState, syncMissingNearcoreState, syncGenesisState } = require("./sync");
+const {
+  syncNewNearcoreState,
+  syncMissingNearcoreState,
+  syncGenesisState
+} = require("./sync");
 const { setupWamp } = require("./wamp");
 
 async function main() {
@@ -53,8 +57,6 @@ async function main() {
     regularSyncMissingNearcoreState,
     regularSyncMissingNearcoreStateInterval
   );
-
-
 
   const wamp = setupWamp();
   console.log("Starting WAMP worker...");

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,15 +2,24 @@ const models = require("../models");
 
 const {
   regularSyncNewNearcoreStateInterval,
-  regularSyncMissingNearcoreStateInterval
+  regularSyncMissingNearcoreStateInterval,
 } = require("./config");
-const { syncNewNearcoreState, syncMissingNearcoreState } = require("./sync");
+const { syncNewNearcoreState, syncMissingNearcoreState, syncGenesisState } = require("./sync");
 const { setupWamp } = require("./wamp");
 
 async function main() {
   console.log("Starting NEAR Explorer backend service...");
 
   await models.sequelize.sync();
+
+  const regularSyncGenesisState = async () => {
+    try {
+      await syncGenesisState();
+    } catch (error) {
+      console.warn("Regular syncing Genesis state crashed due to:", error);
+    }
+  };
+  setTimeout(regularSyncGenesisState, 0);
 
   // TODO: we should publish (push) the information about the new blocks/transcations via WAMP.
   const regularSyncNewNearcoreState = async () => {
@@ -44,6 +53,8 @@ async function main() {
     regularSyncMissingNearcoreState,
     regularSyncMissingNearcoreStateInterval
   );
+
+
 
   const wamp = setupWamp();
   console.log("Starting WAMP worker...");

--- a/backend/src/sync.js
+++ b/backend/src/sync.js
@@ -1,5 +1,5 @@
 const models = require("../models");
-const moment = require("moment")
+const moment = require("moment");
 
 const {
   syncFetchQueueSize,
@@ -133,7 +133,7 @@ async function saveBlocks(blocksInfo) {
                     .map((tx, index) => {
                       return {
                         accountId: tx.receiver_id,
-                        accountIndex: timestamp * 1000000 + index, 
+                        accountIndex: timestamp * 1000000 + index,
                         createdByTransactionHash: tx.hash,
                         createdAtBlockTimestamp: timestamp
                       };
@@ -151,40 +151,40 @@ async function saveBlocks(blocksInfo) {
   }
 }
 
-async function saveGenesis(time, records){
+async function saveGenesis(time, records) {
   try {
     await models.sequelize.transaction(async transaction => {
       try {
         await Promise.all([
           models.AccessKey.bulkCreate(
             records
-            .filter(record => record.AccessKey !== undefined)
-            .map(record => {
-              let accessKeyType;
-              const permission = record.AccessKey.access_key.permission;
-              if (typeof permission === "string") {
-                accessKeyType = permission;
-              } else if (permission !== undefined) {
-                accessKeyType = Object.keys(permission)[0];
-              } else {
-                throw new Error(
-                  `Unexpected error during access key permission parsing in transaction ${
-                    tx.hash
-                  }: 
+              .filter(record => record.AccessKey !== undefined)
+              .map(record => {
+                let accessKeyType;
+                const permission = record.AccessKey.access_key.permission;
+                if (typeof permission === "string") {
+                  accessKeyType = permission;
+                } else if (permission !== undefined) {
+                  accessKeyType = Object.keys(permission)[0];
+                } else {
+                  throw new Error(
+                    `Unexpected error during access key permission parsing in transaction ${
+                      tx.hash
+                    }: 
                     the permission type is expected to be a string or an object with a single key, 
                     but '${JSON.stringify(permission)}' found.`
-                );
-              }
-              return {
-                accountId: record.AccessKey.account_id,
-                publicKey: record.AccessKey.public_key,
-                accessKeyType
-              };
-            })
+                  );
+                }
+                return {
+                  accountId: record.AccessKey.account_id,
+                  publicKey: record.AccessKey.public_key,
+                  accessKeyType
+                };
+              })
           ),
           models.Account.bulkCreate(
             records
-            .filter(record => record.Account !== undefined)
+              .filter(record => record.Account !== undefined)
               .map((record, index) => {
                 return {
                   accountId: record.Account.account_id,
@@ -400,22 +400,29 @@ async function syncMissingNearcoreState() {
 }
 
 async function syncGenesisState() {
-  const genesisConfig = await nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_config")
-  const genesisTime = moment(genesisConfig.genesis_time).valueOf()
-  const limit = 100
-  let offset = 0, Records = Array(), batchCount;
-  do{
-    let pagination = {offset, limit}
-    console.log(`Sync Genesis Records from ${offset} to ${offset+limit}`)
-    const genesisRecords = await nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_records", [pagination])
-    offset += limit
-    batchCount = genesisRecords.records.length
-    Records = Records.concat(genesisRecords.records)
-  }while(batchCount === limit)
-  console.log(`Final Genesis Records is ${Records.length}`)
-  await saveGenesis(genesisTime, Records)
+  const genesisConfig = await nearRpc.sendJsonRpc(
+    "EXPERIMENTAL_genesis_config"
+  );
+  const genesisTime = moment(genesisConfig.genesis_time).valueOf();
+  const limit = 100;
+  let offset = 0,
+    Records = Array(),
+    batchCount;
+  do {
+    let pagination = { offset, limit };
+    console.log(`Sync Genesis Records from ${offset} to ${offset + limit}`);
+    const genesisRecords = await nearRpc.sendJsonRpc(
+      "EXPERIMENTAL_genesis_records",
+      [pagination]
+    );
+    offset += limit;
+    batchCount = genesisRecords.records.length;
+    Records = Records.concat(genesisRecords.records);
+  } while (batchCount === limit);
+  console.log(`Final Genesis Records is ${Records.length}`);
+  await saveGenesis(genesisTime, Records);
 }
 
 exports.syncNewNearcoreState = syncNewNearcoreState;
 exports.syncMissingNearcoreState = syncMissingNearcoreState;
-exports.syncGenesisState = syncGenesisState
+exports.syncGenesisState = syncGenesisState;

--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -61,6 +61,16 @@ wampHandlers["nearcore-tx"] = async ([transactionHash, accountId]) => {
   return await nearRpc.sendJsonRpc("tx", [transactionHash, accountId]);
 };
 
+wampHandlers["nearcore-EXPERIMENTAL_genesis_records"] = async ([pagination]) => {
+  const genesisRecords =  await nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_records", [pagination])
+  return genesisRecords.records
+}
+
+wampHandlers["nearcore-EXPERIMENTAL_genesis_config"] = async () => {
+  // genesisTime = genesisConfig.genesis_time
+  return await nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_config")
+}
+
 function setupWamp() {
   const wamp = new autobahn.Connection({
     realm: "near-explorer",

--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -50,21 +50,6 @@ wampHandlers["nearcore-tx"] = async ([transactionHash, accountId]) => {
   return await nearRpc.sendJsonRpc("tx", [transactionHash, accountId]);
 };
 
-wampHandlers["nearcore-EXPERIMENTAL_genesis_records"] = async ([
-  pagination
-]) => {
-  const genesisRecords = await nearRpc.sendJsonRpc(
-    "EXPERIMENTAL_genesis_records",
-    [pagination]
-  );
-  return genesisRecords.records;
-};
-
-wampHandlers["nearcore-EXPERIMENTAL_genesis_config"] = async () => {
-  // genesisTime = genesisConfig.genesis_time
-  return await nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_config");
-};
-
 function setupWamp() {
   const wamp = new autobahn.Connection({
     realm: "near-explorer",

--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -61,15 +61,20 @@ wampHandlers["nearcore-tx"] = async ([transactionHash, accountId]) => {
   return await nearRpc.sendJsonRpc("tx", [transactionHash, accountId]);
 };
 
-wampHandlers["nearcore-EXPERIMENTAL_genesis_records"] = async ([pagination]) => {
-  const genesisRecords =  await nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_records", [pagination])
-  return genesisRecords.records
-}
+wampHandlers["nearcore-EXPERIMENTAL_genesis_records"] = async ([
+  pagination
+]) => {
+  const genesisRecords = await nearRpc.sendJsonRpc(
+    "EXPERIMENTAL_genesis_records",
+    [pagination]
+  );
+  return genesisRecords.records;
+};
 
 wampHandlers["nearcore-EXPERIMENTAL_genesis_config"] = async () => {
   // genesisTime = genesisConfig.genesis_time
-  return await nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_config")
-}
+  return await nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_config");
+};
 
 function setupWamp() {
   const wamp = new autobahn.Connection({

--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -62,13 +62,7 @@ export default class extends React.Component<Props> {
           <Col md="4">
             <CardCell
               title="Created"
-              text={
-                account.createdAtBlockTimestamp
-                  ? moment(account.createdAtBlockTimestamp).format(
-                      "MMMM DD, YYYY [at] h:mm:ssa"
-                    )
-                  : "N/A"
-              }
+              text={moment(account.createdAtBlockTimestamp).format("MMMM DD, YYYY [at] h:mm:ssa")}
               className="block-card-created account-card-back border-0"
             />
           </Col>
@@ -76,14 +70,14 @@ export default class extends React.Component<Props> {
             <CardCell
               title="Creation Hash"
               text={
-                account.createdByTransactionHash ? (
+                account.createdByTransactionHash !== "Genesis" ? (
                   <TransactionLink
                     transactionHash={account.createdByTransactionHash}
                   >
                     {account.createdByTransactionHash}
                   </TransactionLink>
                 ) : (
-                  "N/A"
+                  "from Genesis"
                 )
               }
               className="block-card-created-text account-card-back border-0"

--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -62,7 +62,9 @@ export default class extends React.Component<Props> {
           <Col md="4">
             <CardCell
               title="Created"
-              text={moment(account.createdAtBlockTimestamp).format("MMMM DD, YYYY [at] h:mm:ssa")}
+              text={moment(account.createdAtBlockTimestamp).format(
+                "MMMM DD, YYYY [at] h:mm:ssa"
+              )}
               className="block-card-created account-card-back border-0"
             />
           </Col>

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -30,7 +30,7 @@ export default class extends React.Component<Props, State> {
   componentDidMount() {
     this._getDetail();
   }
-  
+
   render() {
     const { accountId, createdAt } = this.props;
     const { amount } = this.state;

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -10,7 +10,7 @@ import Balance from "../utils/Balance";
 
 export interface Props {
   accountId: string;
-  createdAt?: number;
+  createdAt: number;
 }
 
 export interface State {
@@ -26,9 +26,11 @@ export default class extends React.Component<Props, State> {
     const detail = await new AccountsApi().queryAccount(this.props.accountId);
     this.setState({ amount: detail.amount });
   };
+
   componentDidMount() {
     this._getDetail();
   }
+  
   render() {
     const { accountId, createdAt } = this.props;
     const { amount } = this.state;

--- a/frontend/src/components/accounts/__tests__/AccountDetails.test.tsx
+++ b/frontend/src/components/accounts/__tests__/AccountDetails.test.tsx
@@ -17,7 +17,8 @@ describe("<AccountDetails />", () => {
             outTransactionsCount: 0,
             createdAtBlockTimestamp: Number(new Date(2019, 1, 1)),
             createdByTransactionHash:
-              "EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL"
+              "EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL",
+            accountIndex: 1234567890
           }}
         />
       )

--- a/frontend/src/components/utils/autoRefreshHandler.tsx
+++ b/frontend/src/components/utils/autoRefreshHandler.tsx
@@ -125,8 +125,11 @@ export default (
       let endTimestamp;
       switch (category) {
         case "Account":
-          endTimestamp = this.state.items[this.state.items.length - 1]
-            .accountIndex;
+          endTimestamp =
+            this.state.items[this.state.items.length - 1]
+              .createdAtBlockTimestamp *
+              1000000 +
+            this.state.items[this.state.items.length - 1].accountIndex;
           break;
         case "Block":
           endTimestamp = this.state.items[this.state.items.length - 1]
@@ -142,6 +145,7 @@ export default (
         default:
           endTimestamp = undefined;
       }
+      console.log(endTimestamp);
       return endTimestamp;
     };
 

--- a/frontend/src/components/utils/autoRefreshHandler.tsx
+++ b/frontend/src/components/utils/autoRefreshHandler.tsx
@@ -145,7 +145,6 @@ export default (
         default:
           endTimestamp = undefined;
       }
-      console.log(endTimestamp);
       return endTimestamp;
     };
 

--- a/frontend/src/components/utils/autoRefreshHandler.tsx
+++ b/frontend/src/components/utils/autoRefreshHandler.tsx
@@ -126,7 +126,7 @@ export default (
       switch (category) {
         case "Account":
           endTimestamp = this.state.items[this.state.items.length - 1]
-            .createdAtBlockTimestamp;
+            .accountIndex;
           break;
         case "Block":
           endTimestamp = this.state.items[this.state.items.length - 1]

--- a/frontend/src/libraries/explorer-wamp/accounts.ts
+++ b/frontend/src/libraries/explorer-wamp/accounts.ts
@@ -70,8 +70,12 @@ export default class AccountsApi extends ExplorerApi {
         `SELECT account_id as id, created_at_block_timestamp as createdAtBlockTimestamp, 
           created_by_transaction_hash as createdByTransactionHash, account_index as accountIndex
           FROM accounts
-          ${endTimestamp ? `WHERE account_index < :endTimestamp` : ""}
-          ORDER BY account_index DESC
+          ${
+            endTimestamp
+              ? `WHERE (created_at_block_timestamp * 1000000 + account_index) < :endTimestamp`
+              : ""
+          }
+          ORDER BY (created_at_block_timestamp * 1000000 + account_index) DESC
           LIMIT :limit`,
         {
           limit,

--- a/frontend/src/libraries/explorer-wamp/accounts.ts
+++ b/frontend/src/libraries/explorer-wamp/accounts.ts
@@ -1,9 +1,9 @@
 import { ExplorerApi } from ".";
-
 export interface AccountBasicInfo {
   id: string;
-  createdByTransactionHash?: string;
-  createdAtBlockTimestamp?: number;
+  createdByTransactionHash: string;
+  createdAtBlockTimestamp: number;
+  accountIndex: number;
 }
 
 interface AccountStats {
@@ -21,9 +21,9 @@ interface AccountInfo {
 export type Account = AccountBasicInfo & AccountStats & AccountInfo;
 
 export default class AccountsApi extends ExplorerApi {
-  async getAccountInfo(id: string): Promise<AccountStats & AccountInfo> {
+  async getAccountInfo(id: string): Promise<Account> {
     try {
-      const [accountInfo, accountStats] = await Promise.all([
+      const [accountInfo, accountStats, accountBasic] = await Promise.all([
         this.queryAccount(id),
         this.call<AccountStats[]>("select", [
           `SELECT outTransactionsCount.outTransactionsCount, inTransactionsCount.inTransactionsCount FROM
@@ -35,6 +35,15 @@ export default class AccountsApi extends ExplorerApi {
           {
             id
           }
+        ]).then(accounts => accounts[0]),
+        this.call<AccountBasicInfo[]>("select", [
+          `SELECT account_id as id, created_at_block_timestamp as createdAtBlockTimestamp, created_by_transaction_hash as createdByTransactionHash
+            FROM accounts
+            WHERE account_id = :id
+          `,
+          {
+            id
+          }
         ]).then(accounts => accounts[0])
       ]);
       return {
@@ -42,28 +51,11 @@ export default class AccountsApi extends ExplorerApi {
         locked: accountInfo.locked,
         storageUsage: accountInfo.storage_usage,
         storagePaidAt: accountInfo.storage_paid_at,
+        ...accountBasic,
         ...accountStats
       };
     } catch (error) {
       console.error("AccountsApi.getAccountInfo failed to fetch data due to:");
-      console.error(error);
-      throw error;
-    }
-  }
-
-  async getAccountBasic(id: string): Promise<AccountBasicInfo> {
-    try {
-      return await this.call<AccountBasicInfo[]>("select", [
-        `SELECT account_id as id, created_at_block_timestamp as createdAtBlockTimestamp, created_by_transaction_hash as createdByTransactionHash
-          FROM accounts
-          WHERE account_id = :id
-        `,
-        {
-          id
-        }
-      ]).then(accounts => accounts[0]);
-    } catch (error) {
-      console.error("AccountsApi.getAccountBasic failed to fetch data due to:");
       console.error(error);
       throw error;
     }
@@ -75,14 +67,15 @@ export default class AccountsApi extends ExplorerApi {
   ): Promise<AccountBasicInfo[]> {
     try {
       return await this.call("select", [
-        `SELECT account_id as id, created_at_block_timestamp as createdAtBlockTimestamp, created_by_transaction_hash as createdByTransactionHash
+        `SELECT account_id as id, created_at_block_timestamp as createdAtBlockTimestamp, 
+          created_by_transaction_hash as createdByTransactionHash, account_index as accountIndex
           FROM accounts
           ${
             endTimestamp
-              ? `WHERE created_at_block_timestamp < :endTimestamp`
+              ? `WHERE account_index < :endTimestamp`
               : ""
           }
-          ORDER BY created_at_block_timestamp DESC
+          ORDER BY account_index DESC
           LIMIT :limit`,
         {
           limit,
@@ -97,6 +90,6 @@ export default class AccountsApi extends ExplorerApi {
   }
 
   async queryAccount(id: string): Promise<any> {
-    return this.call<any>("nearcore-query", [`account/${id}`, ""]);
+    return await this.call<any>("nearcore-query", [`account/${id}`, ""]);
   }
 }

--- a/frontend/src/libraries/explorer-wamp/accounts.ts
+++ b/frontend/src/libraries/explorer-wamp/accounts.ts
@@ -70,11 +70,7 @@ export default class AccountsApi extends ExplorerApi {
         `SELECT account_id as id, created_at_block_timestamp as createdAtBlockTimestamp, 
           created_by_transaction_hash as createdByTransactionHash, account_index as accountIndex
           FROM accounts
-          ${
-            endTimestamp
-              ? `WHERE account_index < :endTimestamp`
-              : ""
-          }
+          ${endTimestamp ? `WHERE account_index < :endTimestamp` : ""}
           ORDER BY account_index DESC
           LIMIT :limit`,
         {

--- a/frontend/src/pages/accounts/[id].jsx
+++ b/frontend/src/pages/accounts/[id].jsx
@@ -22,41 +22,6 @@ export default class extends React.Component {
     }
   }
 
-  state = {
-    createdAtBlockTimestamp: null,
-    createdByTransactionHash: null
-  };
-
-  _updateBasicAccountInfo = () => {
-    return new AccountsApi()
-      .getAccountBasic(this.props.id)
-      .then(basic => {
-        if (basic) {
-          this.setState({
-            createdAtBlockTimestamp: basic.createdAtBlockTimestamp,
-            createdByTransactionHash: basic.createdByTransactionHash
-          });
-        }
-      })
-      .catch(err => {
-        this.setState({
-          createdAtBlockTimestamp: null,
-          createdByTransactionHash: null
-        });
-        console.error(err);
-      });
-  };
-
-  componentDidMount() {
-    this._updateBasicAccountInfo();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.id != prevProps.id) {
-      this._updateBasicAccountInfo();
-    }
-  }
-
   render() {
     return (
       <>
@@ -67,7 +32,7 @@ export default class extends React.Component {
           {this.props.err ? (
             `Information is not available at the moment. Please, check if the account name is correct or try later.`
           ) : (
-            <AccountDetails account={{ ...this.props, ...this.state }} />
+            <AccountDetails account={{ ...this.props }} />
           )}
         </Content>
         {this.props.err ? (


### PR DESCRIPTION
fix #185 

backend:
1. generate nearcore-EXPERIMENTAL_genesis_records and nearcore-EXPERIMENTAL_genesis_config methods in the src/wamp.js since RPC has this and may use in the future.
2. generate saveGenesis method to insert records into data base. Generate syncGenesisState method in the src/sync.js and expose it in the src/index.js. Do not regular fetch genesis for an hour since it will occur unique error and not insert again at all. other are the same as regularSyncNewNearcoreState.
3. add accountIndex field to make it possible to scroll accounts from genesis. add indexes as transaction table to query 15 accounts.

frontend:
1. delete getAccountBasic function since hash and timestamp from genesis will not be null. Fix getAccountInfo to fetch all necessary account information same time. 
2. delete useless state in [id].js since time and hash is already in the props.
